### PR TITLE
Nbozic master transaction api

### DIFF
--- a/ap_ruby_sdk/Gemfile
+++ b/ap_ruby_sdk/Gemfile
@@ -6,5 +6,6 @@ gemspec
 
 gem 'minitest'
 gem 'multi_json'
+gem 'oj'
 gem 'rest-client'
 gem 'webmock'

--- a/ap_ruby_sdk/Gemfile.lock
+++ b/ap_ruby_sdk/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     minitest (5.4.3)
     multi_json (1.12.0)
     netrc (0.11.0)
+    oj (2.15.0)
     rake (10.4.2)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -40,6 +41,7 @@ DEPENDENCIES
   bundler (~> 1.8)
   minitest
   multi_json
+  oj
   rake (~> 10.0)
   rest-client
   webmock

--- a/ap_ruby_sdk/lib/ap_ruby_sdk.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'rest_client'
+require 'oj'
 require 'multi_json'
 
 # Version
@@ -49,7 +50,7 @@ module ApRubySdk
       # Make params into expected PUT params
     else
       # Make params into POST params
-      payload = params.to_json
+      payload = MultiJson.dump(params, mode: :object)
     end
 
     request_opts = {

--- a/ap_ruby_sdk/lib/ap_ruby_sdk.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk.rb
@@ -25,6 +25,7 @@ require 'ap_ruby_sdk/api_resource'
 require 'ap_ruby_sdk/customer'
 require 'ap_ruby_sdk/payment'
 require 'ap_ruby_sdk/transaction'
+require 'ap_ruby_sdk/redirect_urls'
 
 module ApRubySdk
   @api_base = 'https://api.alternativepayments.com/api'
@@ -50,7 +51,7 @@ module ApRubySdk
       # Make params into expected PUT params
     else
       # Make params into POST params
-      payload = MultiJson.dump(params, mode: :object)
+      payload = MultiJson.dump(params, mode: :compat)
     end
 
     request_opts = {

--- a/ap_ruby_sdk/lib/ap_ruby_sdk.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk.rb
@@ -23,6 +23,7 @@ require 'ap_ruby_sdk/base_model'
 require 'ap_ruby_sdk/api_resource'
 require 'ap_ruby_sdk/customer'
 require 'ap_ruby_sdk/payment'
+require 'ap_ruby_sdk/transaction'
 
 module ApRubySdk
   @api_base = 'https://api.alternativepayments.com/api'
@@ -48,7 +49,7 @@ module ApRubySdk
       # Make params into expected PUT params
     else
       # Make params into POST params
-      payload = MultiJson.dump(params)
+      payload = params.to_json
     end
 
     request_opts = {

--- a/ap_ruby_sdk/lib/ap_ruby_sdk/base_model.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk/base_model.rb
@@ -17,5 +17,11 @@ module ApRubySdk
         end
       end
     end
+
+    def to_json
+      hash = {}
+      instance_variables.each {|var| hash[var.to_s.delete("@")] = instance_variable_get(var) }
+      hash.to_json
+    end
   end
 end

--- a/ap_ruby_sdk/lib/ap_ruby_sdk/redirect_urls.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk/redirect_urls.rb
@@ -1,0 +1,8 @@
+module ApRubySdk
+  class RedirectUrls < BaseModel
+
+    attr_accessor :returnUrl,
+                  :cancelUrl
+
+  end
+end

--- a/ap_ruby_sdk/lib/ap_ruby_sdk/transaction.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk/transaction.rb
@@ -1,0 +1,31 @@
+module ApRubySdk
+  class Transaction < ApiResource
+    include ApRubySdk::ApiOperations::Create
+    include ApRubySdk::ApiOperations::List
+    include ApRubySdk::ApiOperations::Retrieve
+
+    attr_accessor :customer,
+                  :customerId,
+                  :payment,
+                  :token,
+                  :amount,
+                  :currency,
+                  :merchantPassThruData,
+                  :merchantTransactionId,
+                  :description,
+                  :ipAddress,
+                  :status
+
+    def customer=(customer)
+      @customer = Customer.new(customer)
+    end
+
+    def self.url
+      '/transactions'
+    end
+
+    def self.list_members
+      :transactions
+    end
+  end
+end

--- a/ap_ruby_sdk/lib/ap_ruby_sdk/transaction.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk/transaction.rb
@@ -14,10 +14,19 @@ module ApRubySdk
                   :merchantTransactionId,
                   :description,
                   :ipAddress,
-                  :status
+                  :status,
+                  :redirectUrls
 
     def customer=(customer)
       @customer = Customer.new(customer)
+    end
+
+    def payment=(payment)
+      @payment = Payment.new(payment)
+    end
+
+    def redirectUrls=(redirectUrls)
+      @redirectUrls = RedirectUrls.new(redirectUrls)
     end
 
     def self.url

--- a/ap_ruby_sdk/lib/ap_ruby_sdk/util.rb
+++ b/ap_ruby_sdk/lib/ap_ruby_sdk/util.rb
@@ -63,7 +63,8 @@ module ApRubySdk
 
     def self.object_classes
       @object_classes ||= {
-          '/customers' => Customer
+          '/customers' => Customer,
+          '/transactions' => Transaction
       }
     end
   end

--- a/ap_ruby_sdk/test/redirect_urls_test.rb
+++ b/ap_ruby_sdk/test/redirect_urls_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class RedirectUrlsTest < Minitest::Test
+
+  def test_redirect_urls_is_created
+    redirectUrls = ApRubySdk::RedirectUrls.new(
+        'returnUrl' => 'http://plugins.alternativepayments.com/message/success.html',
+        'cancelUrl' => 'http://plugins.alternativepayments.com/message/success.html'
+    )
+
+    assert_equal('http://plugins.alternativepayments.com/message/success.html', redirectUrls.returnUrl)
+    assert_equal('http://plugins.alternativepayments.com/message/success.html', redirectUrls.cancelUrl)
+  end
+
+end

--- a/ap_ruby_sdk/test/transaction_test.rb
+++ b/ap_ruby_sdk/test/transaction_test.rb
@@ -9,6 +9,7 @@ class TransactionTest < Minitest::Test
                     '"id":"trn_d12209838b",'\
                     '"mode":"Live",'\
                     '"customer":{'\
+                      '"^o":"ApRubySdk::Customer",'\
                       '"id":"cus_bd838e3611d34d598",'\
                       '"mode":"Live",'\
                       '"firstName":"John",'\
@@ -67,6 +68,12 @@ class TransactionTest < Minitest::Test
 
     assert_equal('trn_d12209838b', transaction.id)
     assert_equal('Live', transaction.mode)
+    assert_equal(customer.id, transaction.customer.id)
+    assert_equal(customer.firstName, transaction.customer.firstName)
+    assert_equal(customer.lastName, transaction.customer.lastName)
+    assert_equal(customer.email, transaction.customer.email)
+    assert_equal(customer.country, transaction.customer.country)
+    assert_equal(customer.created, transaction.customer.created)
     assert_equal(500, transaction.amount)
     assert_equal('EUR', transaction.currency)
     assert_equal('2016-03-24T15:19:10.7800694Z', transaction.created)

--- a/ap_ruby_sdk/test/transaction_test.rb
+++ b/ap_ruby_sdk/test/transaction_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class TransactionTest < Minitest::Test
+
+  def test_create_sepa_transaction
+    stub_request(:post, 'https://api.alternativepayments.com/api/transactions').
+        with(
+            body: '{'\
+                    '"id":"trn_d12209838b",'\
+                    '"mode":"Live",'\
+                    '"customer":{'\
+                      '"id":"cus_bd838e3611d34d598",'\
+                      '"mode":"Live",'\
+                      '"firstName":"John",'\
+                      '"lastName":"Doe",'\
+                      '"email":"john@doe.com",'\
+                      '"country":"DE",'\
+                      '"created":"2016-03-24T15:19:10.7800694Z"'\
+                    '},'\
+                     '"amount":500,'\
+                    '"currency":"EUR"'\
+                '}',
+            headers: {
+                :authorization => "Basic #{Base64.encode64('test').gsub("\n", '')}",
+                :content_type => 'application/json',
+                :accept => '*/*; q=0.5, application/xml',
+                :accept_encoding => 'gzip, deflate',
+                :user_agent => "AlternativePayments Ruby SDK v#{ApRubySdk::VERSION}"
+            }
+        ).to_return(:status => 200, :body => MultiJson.dump(
+                                      {
+                                          'id' => 'trn_d12209838b',
+                                          'mode' => 'Live',
+                                          'status' => 'Pending',
+                                          'customer' => {
+                                              'id' => 'cus_bd838e3611d34d598',
+                                              'mode' => 'Live',
+                                              'firstName' => 'John',
+                                              'lastName' => 'Doe',
+                                              'email' => 'john@doe.com',
+                                              'country' => 'DE',
+                                              'created' => '2016-03-24T15:19:10.7800694Z'
+                                          },
+                                          'amount' => 500,
+                                          'currency' => 'EUR',
+                                          'created' => '2016-03-24T15:19:10.7800694Z'
+                                      },
+                                      :headers => {}))
+
+    customer = ApRubySdk::Customer.new(
+        'id' => 'cus_bd838e3611d34d598',
+        'mode' => 'Live',
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'email' => 'john@doe.com',
+        'country' => 'DE',
+        'created' => '2016-03-24T15:19:10.7800694Z'
+    )
+
+    transaction = ApRubySdk::Transaction.create(
+        'id' => 'trn_d12209838b',
+        'mode' => 'Live',
+        'customer' => customer,
+        'amount' => 500,
+        'currency' => 'EUR'
+    )
+
+    assert_equal('trn_d12209838b', transaction.id)
+    assert_equal('Live', transaction.mode)
+    assert_equal(500, transaction.amount)
+    assert_equal('EUR', transaction.currency)
+    assert_equal('2016-03-24T15:19:10.7800694Z', transaction.created)
+  end
+
+end

--- a/ap_ruby_sdk/test/transaction_test.rb
+++ b/ap_ruby_sdk/test/transaction_test.rb
@@ -6,17 +6,17 @@ class TransactionTest < Minitest::Test
     stub_request(:post, 'https://api.alternativepayments.com/api/transactions').
         with(
             body: '{'\
-                    '"id":"trn_d12209838b",'\
-                    '"mode":"Live",'\
                     '"customer":{'\
-                      '"^o":"ApRubySdk::Customer",'\
                       '"id":"cus_bd838e3611d34d598",'\
-                      '"mode":"Live",'\
                       '"firstName":"John",'\
                       '"lastName":"Doe",'\
                       '"email":"john@doe.com",'\
-                      '"country":"DE",'\
-                      '"created":"2016-03-24T15:19:10.7800694Z"'\
+                      '"country":"DE"'\
+                    '},'\
+                    '"payment":{'\
+                      '"paymentOption":"SEPA",'\
+                      '"holder":"John Doe",'\
+                      '"iban":"DE71XXXXX3330"'\
                     '},'\
                      '"amount":500,'\
                     '"currency":"EUR"'\
@@ -42,6 +42,13 @@ class TransactionTest < Minitest::Test
                                               'country' => 'DE',
                                               'created' => '2016-03-24T15:19:10.7800694Z'
                                           },
+                                          'payment' => {
+                                              'id' => 'pay_ffd25121f84e4d249',
+                                              'mode' => 'Live',
+                                              'holder' => 'John Doe',
+                                              'paymentOption' => 'SEPA',
+                                              'iban' => 'DE71XXXXX3330'
+                                          },
                                           'amount' => 500,
                                           'currency' => 'EUR',
                                           'created' => '2016-03-24T15:19:10.7800694Z'
@@ -50,18 +57,21 @@ class TransactionTest < Minitest::Test
 
     customer = ApRubySdk::Customer.new(
         'id' => 'cus_bd838e3611d34d598',
-        'mode' => 'Live',
         'firstName' => 'John',
         'lastName' => 'Doe',
         'email' => 'john@doe.com',
-        'country' => 'DE',
-        'created' => '2016-03-24T15:19:10.7800694Z'
+        'country' => 'DE'
+    )
+
+    payment = ApRubySdk::Payment.new(
+        'paymentOption' => 'SEPA',
+        'holder' => 'John Doe',
+        'iban' => 'DE71XXXXX3330'
     )
 
     transaction = ApRubySdk::Transaction.create(
-        'id' => 'trn_d12209838b',
-        'mode' => 'Live',
         'customer' => customer,
+        'payment' => payment,
         'amount' => 500,
         'currency' => 'EUR'
     )
@@ -69,11 +79,124 @@ class TransactionTest < Minitest::Test
     assert_equal('trn_d12209838b', transaction.id)
     assert_equal('Live', transaction.mode)
     assert_equal(customer.id, transaction.customer.id)
+    assert_equal('Live', transaction.customer.mode)
     assert_equal(customer.firstName, transaction.customer.firstName)
     assert_equal(customer.lastName, transaction.customer.lastName)
     assert_equal(customer.email, transaction.customer.email)
     assert_equal(customer.country, transaction.customer.country)
-    assert_equal(customer.created, transaction.customer.created)
+    assert_equal('2016-03-24T15:19:10.7800694Z', transaction.customer.created)
+    assert_equal('pay_ffd25121f84e4d249', transaction.payment.id)
+    assert_equal('Live', transaction.payment.mode)
+    assert_equal(payment.holder, transaction.payment.holder)
+    assert_equal(payment.paymentOption, transaction.payment.paymentOption)
+    assert_equal(payment.iban, transaction.payment.iban)
+    assert_equal(500, transaction.amount)
+    assert_equal('EUR', transaction.currency)
+    assert_equal('2016-03-24T15:19:10.7800694Z', transaction.created)
+  end
+
+  def test_create_mistercash_transaction
+    stub_request(:post, 'https://api.alternativepayments.com/api/transactions').
+        with(
+            body: '{'\
+                    '"customer":{'\
+                      '"id":"cus_bd838e3611d34d598",'\
+                      '"firstName":"John",'\
+                      '"lastName":"Doe",'\
+                      '"email":"john@doe.com",'\
+                      '"country":"DE"'\
+                    '},'\
+                    '"payment":{'\
+                      '"paymentOption":"mistercash",'\
+                      '"holder":"John Doe"'\
+                    '},'\
+                     '"amount":500,'\
+                    '"currency":"EUR",'\
+                    '"redirectUrls":{'\
+                      '"returnUrl":"http://plugins.alternativepayments.com/message/success.html",'\
+                      '"cancelUrl":"http://plugins.alternativepayments.com/message/failure.html"'\
+                    '}'\
+                '}',
+            headers: {
+                :authorization => "Basic #{Base64.encode64('test').gsub("\n", '')}",
+                :content_type => 'application/json',
+                :accept => '*/*; q=0.5, application/xml',
+                :accept_encoding => 'gzip, deflate',
+                :user_agent => "AlternativePayments Ruby SDK v#{ApRubySdk::VERSION}"
+            }
+        ).to_return(:status => 200, :body => MultiJson.dump(
+        {
+            'id' => 'trn_d12209838b',
+            'mode' => 'Live',
+            'status' => 'Pending',
+            'customer' => {
+                'id' => 'cus_bd838e3611d34d598',
+                'mode' => 'Live',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'email' => 'john@doe.com',
+                'country' => 'DE',
+                'created' => '2016-03-24T15:19:10.7800694Z'
+            },
+            'payment' => {
+                'id' => 'pay_ffd25121f84e4d249',
+                'mode' => 'Live',
+                'holder' => 'John Doe',
+                'paymentOption' => 'mistercash'
+            },
+            'amount' => 500,
+            'currency' => 'EUR',
+            'merchantPassThruData'=> 'Order #1234958',
+            'created' => '2016-03-24T15:19:10.7800694Z',
+            'redirectUrls'=> {
+              'returnUrl'=> 'http://plugins.alternativepayments.com/message/success.html',
+              'cancelUrl'=> 'http://plugins.alternativepayments.com/message/failure.html'
+            },
+        },
+        :headers => {}))
+
+    customer = ApRubySdk::Customer.new(
+        'id' => 'cus_bd838e3611d34d598',
+        'firstName' => 'John',
+        'lastName' => 'Doe',
+        'email' => 'john@doe.com',
+        'country' => 'DE'
+    )
+
+    payment = ApRubySdk::Payment.new(
+        'paymentOption' => 'mistercash',
+        'holder' => 'John Doe'
+    )
+
+    redirectUrls = ApRubySdk::RedirectUrls.new(
+        'returnUrl' => 'http://plugins.alternativepayments.com/message/success.html',
+        'cancelUrl' => 'http://plugins.alternativepayments.com/message/failure.html'
+    )
+
+    transaction = ApRubySdk::Transaction.create(
+        'customer' => customer,
+        'payment' => payment,
+        'amount' => 500,
+        'currency' => 'EUR',
+        'redirectUrls' => redirectUrls
+    )
+
+    assert_equal('trn_d12209838b', transaction.id)
+    assert_equal('Live', transaction.mode)
+    assert_equal(customer.id, transaction.customer.id)
+    assert_equal('Live', transaction.customer.mode)
+    assert_equal(customer.firstName, transaction.customer.firstName)
+    assert_equal(customer.lastName, transaction.customer.lastName)
+    assert_equal(customer.email, transaction.customer.email)
+    assert_equal(customer.country, transaction.customer.country)
+    assert_equal('2016-03-24T15:19:10.7800694Z', transaction.customer.created)
+    assert_equal('pay_ffd25121f84e4d249', transaction.payment.id)
+    assert_equal('Live', transaction.payment.mode)
+    assert_equal(payment.holder, transaction.payment.holder)
+    assert_equal(payment.paymentOption, transaction.payment.paymentOption)
+    assert_equal(payment.iban, transaction.payment.iban)
+    assert_equal(redirectUrls.returnUrl, transaction.redirectUrls.returnUrl)
+    assert_equal(redirectUrls.cancelUrl, transaction.redirectUrls.cancelUrl)
     assert_equal(500, transaction.amount)
     assert_equal('EUR', transaction.currency)
     assert_equal('2016-03-24T15:19:10.7800694Z', transaction.created)


### PR DESCRIPTION
@looser990 multi-json is just library which is creating compatible API with many JSON libraries out there, so if you want to switch you have easy time. Oj library is one of those which has nice documentation, it is recommended as first choice because of speed and has option to recursively serialize deep objects.

However there is a problem, when doing serialization one of fields is ^o and value is object (check out the test).

So basically we have two options:

1. Leave it like this and use it, while sending one additional field (we should evaluate do we need library for this)
2. Remove both multi-json and oj and implement to_json on base entity, which will work and when you call to_json on parent object it will call to_json on all underlying objects in recursion

Check this out and decide which way we should go.